### PR TITLE
fix(ci): clear govulncheck stdlib findings + fix broken action versions

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -56,7 +56,7 @@ jobs:
       # Regenerate the chart README from README.md.gotmpl + value annotations and
       # fail if it drifts from the committed copy.
       - name: helm-docs is in sync (norwoodj/helm-docs)
-        uses: losisin/helm-docs-action@v1
+        uses: losisin/helm-docs-github-action@v2
         with:
           chart-search-root: ${{ env.CHART_DIR }}
           fail-on-diff: true

--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -72,7 +72,7 @@ jobs:
           build-args: |
             VERSION=main-${{ steps.vars.outputs.shortsha }}
 
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v3
         with:
           cosign-release: 'v3.0.6'
 
@@ -88,7 +88,7 @@ jobs:
 
       - uses: azure/setup-helm@v4
 
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v3
         with:
           cosign-release: 'v3.0.6'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # cosign (keyless image + checksum signing) and syft (SBOMs).
-      - uses: sigstore/cosign-installer@v4
+      - uses: sigstore/cosign-installer@v3
         with:
           cosign-release: 'v3.0.6'
       - uses: anchore/sbom-action/download-syft@v0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rknightion/tailscale2otel
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/klauspost/compress v1.18.6


### PR DESCRIPTION
Fixes three unrelated CI failures.

## 1. govulncheck — 16 stdlib vulnerabilities
All 16 findings were in the Go **standard library** (net/textproto, crypto/x509, html/template, net, crypto/tls, net/url, os), each fixed in a `go1.26.x` patch. CI builds with the version pinned via `go-version-file: go.mod`, which was `1.26.0`.

- Bumped the `go` directive to **`1.26.4`** (highest fix version; current latest 1.26 patch).
- Verified locally with Go 1.26.4: `go build ./...` ✅, `go vet ./...` ✅, `govulncheck@v1.3.0 ./...` → **"No vulnerabilities found"**.

## 2. `sigstore/cosign-installer@v4` — unresolvable (Main publish + Release)
The action publishes only full-semver tags plus a moving **`v3`** tag — there is **no moving `v4` tag**, so `@v4` failed with *"unable to find version v4"*. Fixed all 3 occurrences (main-publish ×2, release ×1) → **`@v3`**, matching the moving-major-tag convention used by every other action here. The cosign binary stays pinned via `cosign-release: 'v3.0.6'`.

## 3. `losisin/helm-docs-action@v1` — repository not found (Helm)
That repo doesn't exist. The real one is **`losisin/helm-docs-github-action`** → switched to its `@v2` moving tag (matches the sibling `helm-values-schema-json-action@v2`). Its `action.yaml` accepts the same `chart-search-root` / `fail-on-diff` inputs already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)