### PR TITLE
fix: restrict main snapshot publishing to main ref

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -42,6 +42,9 @@ jobs:
   image:
     name: build + push + sign snapshot image
     needs: vars
+    # Manual dispatches can be started from arbitrary refs; only publish/sign
+    # artifacts when the workflow is actually running on the protected main ref.
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write # push image + attestations to ghcr.io
@@ -82,6 +85,9 @@ jobs:
     name: push + sign snapshot chart
     runs-on: ubuntu-latest
     needs: [vars, image]
+    # Match the image job's branch guard so manually dispatched non-main refs
+    # cannot publish/sign main-named chart snapshots.
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write # push chart to ghcr.io


### PR DESCRIPTION
### Motivation
- The `main-publish` workflow exposed a supply-chain risk by allowing `workflow_dispatch` to run publishing and OIDC signing jobs from arbitrary refs while always emitting `main`-named artifacts, enabling non-main code to publish signed artifacts that appear to be main snapshots.

### Description
- Add `if: github.ref == 'refs/heads/main'` to the `image` job in `/.github/workflows/main-publish.yml` so the image build/push/sign steps only run when the workflow is actually on the protected `main` branch.  
- Add the same `if: github.ref == 'refs/heads/main'` to the `chart` job in `/.github/workflows/main-publish.yml` so Helm chart packaging/pushing/signing is likewise restricted to the `main` branch.

### Testing
- Ran a Python assertion script that verified `workflow_dispatch` remains enabled and that both publishing jobs include `if: github.ref == 'refs/heads/main'`, and it passed.  
- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/main-publish.yml')"` to ensure the file is valid YAML, and it succeeded.  
- Executed `git diff --check` to validate no whitespace issues, and it returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20a7c800608324a4f905899ac5a467)