### PR TITLE
Bound receiver request bodies and add server timeouts

### DIFF
--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -592,6 +592,9 @@ func (s *Server) Run(ctx context.Context) error {
 		Addr:              s.listen,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -53,6 +53,9 @@ const (
 	// MetricRejected counts rejected webhook requests, keyed by rejection reason.
 	MetricRejected = "tailscale.webhook.rejected"
 
+	// defaultMaxBodyBytes caps webhook request bodies when Options.MaxBodyBytes is 0.
+	defaultMaxBodyBytes = 64 << 20 // 64 MiB
+
 	// eventNamePrefix is prepended to the Tailscale event type to form the OTEL
 	// LogRecord EventName, e.g. "tailscale.webhook.nodeCreated".
 	eventNamePrefix = "tailscale.webhook."
@@ -110,6 +113,10 @@ type Options struct {
 	// Tolerance is the maximum age of a request timestamp before it is rejected
 	// as a replay. Zero disables the check.
 	Tolerance time.Duration
+	// MaxBodyBytes caps the raw request body size before signature verification,
+	// bounding unauthenticated memory use. 0 selects a 64 MiB default; a negative
+	// value disables the cap.
+	MaxBodyBytes int64
 }
 
 // Server receives and verifies Tailscale webhook POSTs and emits telemetry.
@@ -187,6 +194,9 @@ func (s *Server) Run(ctx context.Context) error {
 		Addr:              s.opts.Listen,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	errCh := make(chan error, 1)
@@ -218,8 +228,13 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	body, err := io.ReadAll(r.Body)
+	body, err := s.readBody(w, r)
 	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			s.rejectStatus(w, http.StatusRequestEntityTooLarge, "too_large", "request body exceeds max size", err)
+			return
+		}
 		s.reject(w, "read_error", "failed to read request body", err)
 		return
 	}
@@ -244,15 +259,31 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func (s *Server) readBody(w http.ResponseWriter, r *http.Request) ([]byte, error) {
+	limit := s.opts.MaxBodyBytes
+	if limit == 0 {
+		limit = defaultMaxBodyBytes
+	}
+	reader := r.Body
+	if limit >= 0 {
+		reader = http.MaxBytesReader(w, r.Body, limit)
+	}
+	return io.ReadAll(reader)
+}
+
 // reject records the rejection counter, logs at Warn, and writes a 401. A
 // "read_error" or "invalid_body" reason still uses 401 here for simplicity:
 // the body could not be authenticated as a well-formed signed payload.
 func (s *Server) reject(w http.ResponseWriter, reason, msg string, err error) {
+	s.rejectStatus(w, http.StatusUnauthorized, reason, msg, err)
+}
+
+func (s *Server) rejectStatus(w http.ResponseWriter, status int, reason, msg string, err error) {
 	s.logger.Warn(msg, "reason", reason, "error", err)
 	s.e.Counter(docWebhookRejected.Name, docWebhookRejected.Unit, docWebhookRejected.Description, 1, telemetry.Attrs{
 		attrReason: reason,
 	})
-	http.Error(w, "unauthorized", http.StatusUnauthorized)
+	http.Error(w, http.StatusText(status), status)
 }
 
 // verify checks the signature header against the body using opts.Secret. It

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -169,6 +169,46 @@ func TestHandler_MultiSignatureRotationVerifies(t *testing.T) {
 	}
 }
 
+func TestHandler_MaxBodyBytesTooLargeRejectedBeforeSignature(t *testing.T) {
+	rec := telemetrytest.New()
+	s := New(Options{
+		Path:         "/webhook",
+		Secret:       testSecret,
+		MaxBodyBytes: 8,
+	}, rec.Emitter(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	resp := doPost(t, s.Handler(), "/webhook", strings.Repeat("x", 100), "")
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+	pts := rec.MetricPoints("tailscale.webhook.rejected")
+	if len(pts) != 1 {
+		t.Fatalf("rejected metric points = %d, want 1 (%+v)", len(pts), pts)
+	}
+	if got := pts[0].Attrs["reason"]; got != "too_large" {
+		t.Fatalf("rejected reason = %q, want too_large", got)
+	}
+}
+
+func TestHandler_MaxBodyBytesUnderLimitStillVerifies(t *testing.T) {
+	rec := telemetrytest.New()
+	s := New(Options{
+		Path:         "/webhook",
+		Secret:       testSecret,
+		MaxBodyBytes: int64(len(twoEventBody)),
+	}, rec.Emitter(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ts := time.Date(2026, 6, 2, 10, 6, 0, 0, time.UTC)
+	sig := signBody(testSecret, ts, twoEventBody)
+	resp := doPost(t, s.Handler(), "/webhook", twoEventBody, sig)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := len(rec.LogRecords()); got != 2 {
+		t.Fatalf("LogRecords len = %d, want 2", got)
+	}
+}
+
 func TestHandler_TamperedSignatureRejected(t *testing.T) {
 	s, rec := newTestServer(t)
 


### PR DESCRIPTION
### Motivation

- Prevent unbounded `io.ReadAll` of request bodies before authentication which can allow unauthenticated clients to exhaust memory or tie up goroutines. 
- Add server-side timeouts to limit slow request bodies/connections that are currently only bounded by `ReadHeaderTimeout`.

### Description

- Add `Options.MaxBodyBytes` and `defaultMaxBodyBytes = 64 << 20` to the webhook receiver and introduce `readBody` which uses `http.MaxBytesReader` to cap the raw request body pre-authentication (negative disables the cap). 
- Make oversized webhook requests return `413` and emit a `too_large` rejection metric before signature verification; preserve existing behavior for other read/parse errors. 
- Add `ReadTimeout`, `WriteTimeout`, and `IdleTimeout` to both webhook and stream HTTP servers to bound slow or lingering connections. 
- Keep the stream receiver's decompressed-body cap behavior (`MaxBodyBytes` / `readAllLimited`) unchanged; only the stream server timeouts were added. 
- Add `rejectStatus` helper and update webhook response handling to use `http.StatusText(status)` for error bodies. 
- Add tests `TestHandler_MaxBodyBytesTooLargeRejectedBeforeSignature` and `TestHandler_MaxBodyBytesUnderLimitStillVerifies` to `internal/webhook/webhook_test.go` that validate pre-auth size rejection and normal signed handling.

### Testing

- Ran `go test ./internal/webhook ./internal/stream` and both packages passed. 
- Ran full test suite `go test ./...` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20ae9b69f08324b495f1ab3c389e61)