### PR TITLE
fix(nodemetrics): bound discovered scrape work

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -65,11 +65,13 @@ collectors:
   # Optional: scrape tailscaled per-node Prometheus /metrics endpoints and forward
   # them centrally over OTLP (counters as deltas, gauges as gauges, plus a per-target
   # tailscale.node.up gauge). Node identity is carried as the "instance" label, not an
-  # OTEL Resource. Off by default; disabled when no targets are configured.
+  # OTEL Resource. Off by default; enable with static targets and/or discovery.
   node_metrics:
     enabled: false
     interval: 60s
     timeout: 10s
+    max_response_bytes: 4194304  # per-target response cap (4 MiB)
+    max_samples: 50000           # per-target sample cap per scrape
     targets: []
       # - url: "http://100.64.0.10:5252/metrics"
       #   instance: "relay-1"          # defaults to the URL host:port if omitted
@@ -93,6 +95,7 @@ collectors:
     discovery:
       enabled: false
       interval: 5m
+      max_targets: 1000         # cap discovered scrape targets per refresh
       scheme: http              # http | https
       port: 5252                # tailscaled client metrics port
       path: /metrics

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -276,7 +276,8 @@ Key behavior:
   (anchored regexes on the forwarded metric **name**, allow-then-deny) and `drop_labels` (label keys
   stripped from every forwarded series) trim the verbatim stream. They never affect
   `tailscale.node.up` or the `tailscale2otel.nodemetrics.discovery.*` gauges, and the `instance`
-  label is never dropped.
+  label is never dropped. The scraper also enforces per-target `max_response_bytes` / `max_samples`
+  limits, while dynamic discovery is bounded by `discovery.max_targets`.
 
 Node identity is carried as **labels** (notably `instance`) on the forwarded series, **not** as
 OTEL Resource attributes. This keeps the forwarded metrics queryable alongside the rest of the

--- a/docs/node-metrics.md
+++ b/docs/node-metrics.md
@@ -154,8 +154,7 @@ terminate, **the grant is the access-control boundary** — keep it as narrow as
 ## Wiring up the scraper
 
 The scraper lives under [`collectors.node_metrics`](../config.example.yaml) and is **off by
-default** (and stays disabled when no targets are configured). A minimal config for native
-endpoints needs nothing more than the URL:
+default**. A minimal static-target config for native endpoints needs nothing more than the URL:
 
 ```yaml
 collectors:
@@ -163,6 +162,8 @@ collectors:
     enabled: true
     interval: 60s
     timeout: 10s
+    max_response_bytes: 4194304  # per-target response cap (4 MiB)
+    max_samples: 50000           # per-target sample cap per scrape
     targets:
       - url: "http://100.64.0.10:5252/metrics"
         instance: "relay-1"          # defaults to the URL host:port if omitted
@@ -183,6 +184,17 @@ scrape is a plain `GET` with no added headers.
 - **Node identity = the `instance` label.** Every forwarded series carries an `instance` label
   (your `instance:` value, or the URL `host:port` if omitted) — identity is a **label, not an OTEL
   Resource**. See the [reference](./metrics.md#node-metrics-scraper) for how these query in Grafana.
+
+### Scrape and discovery safety limits
+
+The scraper enforces bounded work per node. `max_response_bytes` caps the number of bytes read from
+one target response (default `4194304`, 4 MiB), and `max_samples` caps the number of valid samples
+accepted from one scrape (default `50000`). A target that exceeds either limit is treated as a failed
+scrape and reports `tailscale.node.up=0` for that collection.
+
+When dynamic discovery is enabled, `discovery.max_targets` caps the number of discovered devices that
+can become scrape targets in one refresh (default `1000`). Use `include_tags`/`exclude_tags` together
+with this cap to keep automatic discovery scoped to the nodes you intend to scrape.
 
 ### Optional per-target auth & TLS (proxied / HTTPS targets only)
 

--- a/internal/app/nodediscovery.go
+++ b/internal/app/nodediscovery.go
@@ -46,7 +46,11 @@ func (d *nodeDiscoverer) Discover(ctx context.Context) ([]nodemetrics.Target, er
 	if err != nil {
 		return nil, err
 	}
-	out := make([]nodemetrics.Target, 0, len(devs))
+	capHint := len(devs)
+	if d.cfg.MaxTargets > 0 && capHint > d.cfg.MaxTargets {
+		capHint = d.cfg.MaxTargets
+	}
+	out := make([]nodemetrics.Target, 0, capHint)
 	for i := range devs {
 		dev := &devs[i]
 		if !d.match(dev) {
@@ -57,6 +61,9 @@ func (d *nodeDiscoverer) Discover(ctx context.Context) ([]nodemetrics.Target, er
 			continue // no usable Tailscale address
 		}
 		out = append(out, d.toTarget(dev, addr))
+		if d.cfg.MaxTargets > 0 && len(out) >= d.cfg.MaxTargets {
+			break
+		}
 	}
 	return out, nil
 }

--- a/internal/app/nodediscovery_test.go
+++ b/internal/app/nodediscovery_test.go
@@ -148,6 +148,23 @@ func TestNodeDiscoverer_PassthroughLabels(t *testing.T) {
 	}
 }
 
+func TestNodeDiscoverer_MaxTargetsCapsDiscovery(t *testing.T) {
+	cfg := discoveryDefaults()
+	cfg.MaxTargets = 2
+	devs := []tsapi.RichDevice{
+		{Hostname: "a", Addresses: []string{"100.64.0.1"}, ConnectedToControl: true},
+		{Hostname: "b", Addresses: []string{"100.64.0.2"}, ConnectedToControl: true},
+		{Hostname: "c", Addresses: []string{"100.64.0.3"}, ConnectedToControl: true},
+	}
+	got := mustDiscover(t, devs, cfg)
+	if len(got) != 2 {
+		t.Fatalf("targets = %d, want capped to 2; got %+v", len(got), got)
+	}
+	if got[0].URL != "http://100.64.0.1:5252/metrics" || got[1].URL != "http://100.64.0.2:5252/metrics" {
+		t.Fatalf("targets = %+v, want first two matching devices", got)
+	}
+}
+
 func TestNodeDiscoverer_APIErrorPropagates(t *testing.T) {
 	want := errors.New("boom")
 	_, err := newNodeDiscoverer(&fakeDevicesAPI{err: want}, discoveryDefaults()).Discover(context.Background())

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -82,12 +82,14 @@ func nodeMetricsOptions(nm config.NodeMetricsConfig, api nodeDiscoveryAPI) nodem
 		targets = append(targets, nt)
 	}
 	opts := nodemetrics.Options{
-		Targets:     targets,
-		Interval:    nm.Interval.D(),
-		Timeout:     nm.Timeout.D(),
-		MetricAllow: nm.MetricAllow,
-		MetricDeny:  nm.MetricDeny,
-		DropLabels:  nm.DropLabels,
+		Targets:          targets,
+		Interval:         nm.Interval.D(),
+		Timeout:          nm.Timeout.D(),
+		MaxResponseBytes: nm.MaxResponseBytes,
+		MaxSamples:       nm.MaxSamples,
+		MetricAllow:      nm.MetricAllow,
+		MetricDeny:       nm.MetricDeny,
+		DropLabels:       nm.DropLabels,
 	}
 	// Dynamic discovery: poll the Tailscale device inventory on its own interval
 	// and union the result with the static targets (handled by the collector).

--- a/internal/collector/nodemetrics/nodemetrics.go
+++ b/internal/collector/nodemetrics/nodemetrics.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -45,6 +46,8 @@ const (
 	defaultInterval          = 60 * time.Second
 	defaultTimeout           = 10 * time.Second
 	defaultDiscoveryInterval = 5 * time.Minute
+	defaultMaxResponseBytes  = 4 * 1024 * 1024
+	defaultMaxSamples        = 50000
 
 	// metricUp is the per-target scrape health gauge.
 	metricUp = "tailscale.node.up"
@@ -124,6 +127,8 @@ type Options struct {
 	Now               func() time.Time
 	Discoverer        Discoverer
 	DiscoveryInterval time.Duration
+	MaxResponseBytes  int64
+	MaxSamples        int
 
 	// Passthrough filters applied to forwarded samples only (never to
 	// tailscale.node.up or the discovery.* gauges). MetricAllow/MetricDeny are
@@ -151,6 +156,8 @@ type Collector struct {
 	discoverer        Discoverer
 	discoveryInterval time.Duration
 	timeout           time.Duration // resolved scrape timeout, for building discovered clients
+	maxResponseBytes  int64
+	maxSamples        int
 
 	metricAllow []*regexp.Regexp    // anchored name allowlist; empty => allow all
 	metricDeny  []*regexp.Regexp    // anchored name denylist; applied after allow
@@ -192,6 +199,14 @@ func New(opts Options) *Collector {
 	if opts.Discoverer != nil && discoveryInterval <= 0 {
 		discoveryInterval = defaultDiscoveryInterval
 	}
+	maxResponseBytes := opts.MaxResponseBytes
+	if maxResponseBytes <= 0 {
+		maxResponseBytes = defaultMaxResponseBytes
+	}
+	maxSamples := opts.MaxSamples
+	if maxSamples <= 0 {
+		maxSamples = defaultMaxSamples
+	}
 	static := resolveTargets(opts.Targets, timeout)
 	return &Collector{
 		static:            static,
@@ -201,6 +216,8 @@ func New(opts Options) *Collector {
 		discoverer:        opts.Discoverer,
 		discoveryInterval: discoveryInterval,
 		timeout:           timeout,
+		maxResponseBytes:  maxResponseBytes,
+		maxSamples:        maxSamples,
 		metricAllow:       compileAnchored(opts.MetricAllow),
 		metricDeny:        compileAnchored(opts.MetricDeny),
 		dropLabels:        toSet(opts.DropLabels),
@@ -428,6 +445,39 @@ func (c *Collector) clientOf(rt *resolvedTarget) *http.Client {
 	return c.client
 }
 
+// errResponseTooLarge is returned when a target response exceeds the configured
+// per-scrape byte budget.
+var errResponseTooLarge = fmt.Errorf("nodemetrics: response exceeds max_response_bytes")
+
+type maxBytesReadCloser struct {
+	r         io.ReadCloser
+	remaining int64
+}
+
+func limitedReadCloser(r io.ReadCloser, max int64) io.Reader {
+	if max <= 0 {
+		return r
+	}
+	return &maxBytesReadCloser{r: r, remaining: max}
+}
+
+func (r *maxBytesReadCloser) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		var one [1]byte
+		n, err := r.r.Read(one[:])
+		if n > 0 {
+			return 0, errResponseTooLarge
+		}
+		return 0, err
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:int(r.remaining)]
+	}
+	n, err := r.r.Read(p)
+	r.remaining -= int64(n)
+	return n, err
+}
+
 // scrapeTarget fetches and re-emits one target. It always emits the per-target
 // tailscale.node.up health gauge (1 on success, 0 on any GET/read/parse error)
 // and returns a non-nil error on failure so Collect can count it.
@@ -463,7 +513,7 @@ func (c *Collector) fetchAndEmit(ctx context.Context, t *Target, client *http.Cl
 		return fmt.Errorf("nodemetrics: GET %s: status %d", t.URL, resp.StatusCode)
 	}
 
-	samples, err := parse(resp.Body)
+	samples, err := parse(limitedReadCloser(resp.Body, c.maxResponseBytes), c.maxSamples)
 	if err != nil {
 		return err
 	}

--- a/internal/collector/nodemetrics/nodemetrics_test.go
+++ b/internal/collector/nodemetrics/nodemetrics_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -70,6 +71,50 @@ func TestEmptyTargets_CollectNil(t *testing.T) {
 	}
 	if names := rec.MetricNames(); len(names) != 0 {
 		t.Fatalf("MetricNames with no targets = %v, want none", names)
+	}
+}
+
+func TestScrape_MaxResponseBytesRejectsOversizedBody(t *testing.T) {
+	body := strings.Repeat("a", 32)
+	srv := serveText(&body)
+	defer srv.Close()
+
+	c := nodemetrics.New(nodemetrics.Options{
+		Targets:          []nodemetrics.Target{{URL: srv.URL, Instance: "n"}},
+		MaxResponseBytes: 16,
+		MaxSamples:       10,
+	})
+	rec := telemetrytest.New()
+	if err := c.Collect(context.Background(), rec.Emitter()); err == nil {
+		t.Fatal("Collect() error = nil, want oversized response to fail the only target")
+	}
+	if pts := rec.MetricPoints("tailscale.node.up"); len(pts) != 1 || pts[0].Value != 0 {
+		t.Fatalf("tailscale.node.up = %+v, want one down point", pts)
+	}
+}
+
+func TestScrape_MaxSamplesRejectsOversizedSampleSet(t *testing.T) {
+	body := "# TYPE m gauge\n" +
+		"m{series=\"1\"} 1\n" +
+		"m{series=\"2\"} 2\n" +
+		"m{series=\"3\"} 3\n"
+	srv := serveText(&body)
+	defer srv.Close()
+
+	c := nodemetrics.New(nodemetrics.Options{
+		Targets:          []nodemetrics.Target{{URL: srv.URL, Instance: "n"}},
+		MaxResponseBytes: 1024,
+		MaxSamples:       2,
+	})
+	rec := telemetrytest.New()
+	if err := c.Collect(context.Background(), rec.Emitter()); err == nil {
+		t.Fatal("Collect() error = nil, want oversized sample set to fail the only target")
+	}
+	if pts := rec.MetricPoints("m"); len(pts) != 0 {
+		t.Fatalf("m = %+v, want no forwarded samples after sample-limit failure", pts)
+	}
+	if pts := rec.MetricPoints("tailscale.node.up"); len(pts) != 1 || pts[0].Value != 0 {
+		t.Fatalf("tailscale.node.up = %+v, want one down point", pts)
 	}
 }
 

--- a/internal/collector/nodemetrics/parse.go
+++ b/internal/collector/nodemetrics/parse.go
@@ -2,6 +2,7 @@ package nodemetrics
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"math"
 	"strconv"
@@ -35,7 +36,7 @@ const (
 // sample per valid metric line. HELP/TYPE comment lines configure the family
 // metadata applied to following samples; blank and malformed lines are skipped
 // robustly. parse only returns an error for an underlying read failure.
-func parse(r io.Reader) ([]sample, error) {
+func parse(r io.Reader, maxSamples int) ([]sample, error) {
 	types := map[string]familyType{}
 	helps := map[string]string{}
 	var out []sample
@@ -54,6 +55,9 @@ func parse(r io.Reader) ([]sample, error) {
 		}
 		s, ok := parseSample(line, types, helps)
 		if ok {
+			if maxSamples > 0 && len(out) >= maxSamples {
+				return nil, fmt.Errorf("nodemetrics: sample count exceeds max_samples (%d)", maxSamples)
+			}
 			out = append(out, s)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,10 @@ type NodeMetricsConfig struct {
 	Targets   []NodeMetricsTarget  `yaml:"targets"`
 	Discovery NodeMetricsDiscovery `yaml:"discovery"`
 
+	// Scrape limits bound memory and telemetry cardinality per target.
+	MaxResponseBytes int64 `yaml:"max_response_bytes"` // maximum response bytes read from one scrape
+	MaxSamples       int   `yaml:"max_samples"`        // maximum valid samples forwarded from one scrape
+
 	// Passthrough filters on the FORWARDED Prometheus samples. They never affect
 	// tailscale.node.up or the discovery.* gauges. A zero value means no filtering.
 	MetricAllow []string `yaml:"metric_allow"` // anchored regex on the forwarded metric NAME; if non-empty, a name must match one to be forwarded
@@ -161,6 +165,7 @@ type NodeMetricsDiscovery struct {
 	Path   string `yaml:"path"`   // default "/metrics"
 
 	// Filters.
+	MaxTargets      int      `yaml:"max_targets"`      // maximum discovered targets per refresh
 	OnlineOnly      bool     `yaml:"online_only"`      // default true: only connectedToControl devices
 	ExcludeExternal bool     `yaml:"exclude_external"` // default true: skip shared/external devices
 	IncludeTags     []string `yaml:"include_tags"`     // empty = match all; any-match

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -95,12 +95,15 @@ func Default() *Config {
 				Interval: dur(600 * time.Second),
 			},
 			NodeMetrics: NodeMetricsConfig{
-				Enabled:  false,
-				Interval: dur(60 * time.Second),
-				Timeout:  dur(10 * time.Second),
+				Enabled:          false,
+				Interval:         dur(60 * time.Second),
+				Timeout:          dur(10 * time.Second),
+				MaxResponseBytes: 4 * 1024 * 1024,
+				MaxSamples:       50000,
 				Discovery: NodeMetricsDiscovery{
 					Enabled:           false,
 					Interval:          dur(5 * time.Minute),
+					MaxTargets:        1000,
 					Scheme:            "http",
 					Port:              5252,
 					Path:              "/metrics",

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -169,6 +169,12 @@ func TestNodeMetricsDefaults(t *testing.T) {
 	if len(nm.Targets) != 0 {
 		t.Errorf("NodeMetrics.Targets = %v, want empty by default", nm.Targets)
 	}
+	if nm.MaxResponseBytes != 4*1024*1024 {
+		t.Errorf("NodeMetrics.MaxResponseBytes = %d, want 4MiB", nm.MaxResponseBytes)
+	}
+	if nm.MaxSamples != 50000 {
+		t.Errorf("NodeMetrics.MaxSamples = %d, want 50000", nm.MaxSamples)
+	}
 }
 
 func TestNodeMetricsDiscoveryDefaults(t *testing.T) {
@@ -187,6 +193,9 @@ func TestNodeMetricsDiscoveryDefaults(t *testing.T) {
 	}
 	if d.Path != "/metrics" {
 		t.Errorf("Discovery.Path = %q, want /metrics", d.Path)
+	}
+	if d.MaxTargets != 1000 {
+		t.Errorf("Discovery.MaxTargets = %d, want 1000", d.MaxTargets)
 	}
 	if !d.OnlineOnly {
 		t.Errorf("Discovery.OnlineOnly = false, want default true")
@@ -216,6 +225,7 @@ collectors:
     discovery:
       enabled: true
       interval: 2m
+      max_targets: 12
       port: 9100
       online_only: false
       include_tags: ["tag:server"]
@@ -226,8 +236,8 @@ collectors:
 		t.Fatalf("Load: %v", err)
 	}
 	d := cfg.Collectors.NodeMetrics.Discovery
-	if !d.Enabled || d.Interval.D() != 2*time.Minute || d.Port != 9100 {
-		t.Fatalf("discovery enabled/interval/port = %v/%v/%d", d.Enabled, d.Interval.D(), d.Port)
+	if !d.Enabled || d.Interval.D() != 2*time.Minute || d.Port != 9100 || d.MaxTargets != 12 {
+		t.Fatalf("discovery enabled/interval/port/max_targets = %v/%v/%d/%d", d.Enabled, d.Interval.D(), d.Port, d.MaxTargets)
 	}
 	// An explicit false overrides the true default.
 	if d.OnlineOnly {
@@ -252,6 +262,8 @@ collectors:
   node_metrics:
     enabled: true
     interval: 30s
+    max_response_bytes: 2048
+    max_samples: 123
     targets:
       - url: http://100.64.0.1:5252/metrics
         instance: nodeA
@@ -267,6 +279,9 @@ collectors:
 	nm := cfg.Collectors.NodeMetrics
 	if !nm.Enabled || nm.Interval.D() != 30*time.Second {
 		t.Fatalf("node_metrics enabled/interval = %v/%v", nm.Enabled, nm.Interval.D())
+	}
+	if nm.MaxResponseBytes != 2048 || nm.MaxSamples != 123 {
+		t.Fatalf("node_metrics max_response_bytes/max_samples = %d/%d", nm.MaxResponseBytes, nm.MaxSamples)
 	}
 	// Interval set, Timeout omitted -> default preserved.
 	if nm.Timeout.D() != 10*time.Second {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -124,6 +124,12 @@ func (c *Config) Validate() error {
 				return fmt.Errorf("collectors.node_metrics.targets[%d].url is required", i)
 			}
 		}
+		if nm.MaxResponseBytes <= 0 {
+			return fmt.Errorf("collectors.node_metrics.max_response_bytes must be > 0")
+		}
+		if nm.MaxSamples <= 0 {
+			return fmt.Errorf("collectors.node_metrics.max_samples must be > 0")
+		}
 		// Passthrough metric-name filters are anchored regexes; compile them up
 		// front so a bad pattern is a config error rather than a silent no-op.
 		for i, p := range nm.MetricAllow {
@@ -151,6 +157,9 @@ func (c *Config) Validate() error {
 			}
 			if d.Interval.D() <= 0 {
 				return fmt.Errorf("collectors.node_metrics.discovery.interval must be > 0")
+			}
+			if d.MaxTargets <= 0 {
+				return fmt.Errorf("collectors.node_metrics.discovery.max_targets must be > 0")
 			}
 		}
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -275,6 +275,38 @@ func TestValidateNodeMetricsDiscoveryEnabledZeroTargetsValid(t *testing.T) {
 	}
 }
 
+func TestValidateNodeMetricsRejectsBadLimits(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "max_response_bytes",
+			yaml: "collectors:\n  node_metrics:\n    enabled: true\n    max_response_bytes: 0\n    targets:\n      - url: http://x:5252/metrics\n",
+			want: "max_response_bytes",
+		},
+		{
+			name: "max_samples",
+			yaml: "collectors:\n  node_metrics:\n    enabled: true\n    max_samples: 0\n    targets:\n      - url: http://x:5252/metrics\n",
+			want: "max_samples",
+		},
+		{
+			name: "discovery_max_targets",
+			yaml: "collectors:\n  node_metrics:\n    enabled: true\n    discovery:\n      enabled: true\n      max_targets: 0\n",
+			want: "max_targets",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := loadErr(t, tc.yaml)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want mention %s", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateNodeMetricsRejectsBadMetricAllowRegex(t *testing.T) {
 	const y = "collectors:\n  node_metrics:\n    enabled: true\n    targets:\n      - url: http://x:5252/metrics\n    metric_allow:\n      - \"node_(\"\n"
 	err := loadErr(t, y)


### PR DESCRIPTION
### Motivation

- Dynamic node-metrics discovery could produce an unbounded set of scrape targets and the scraper/parsing path accepted unlimited response bytes and samples, enabling a compromised tailnet device to cause high CPU/memory use or telemetry cardinality/cost spikes.
- The change adds lightweight per-target and discovery caps to make discovery-safe by default while preserving existing functionality.

### Description

- Add three new configurable limits: `collectors.node_metrics.max_response_bytes` (int64), `collectors.node_metrics.max_samples` (int) and `collectors.node_metrics.discovery.max_targets` (int), with defaults `4*1024*1024` (4 MiB), `50000`, and `1000` respectively, and include them in `NodeMetricsConfig` / `NodeMetricsDiscovery` and defaults.
- Validate the new fields in `config.Validate()` so they must be > 0 when `node_metrics.enabled` or discovery is enabled.
- Wire the limits into the collector via `nodeMetricsOptions` -> `nodemetrics.Options` and into `Collector` (new `maxResponseBytes` / `maxSamples`), using defaults when unset. 
- Enforce limits at runtime: wrap HTTP response body with a `limitedReadCloser` bounded by `max_response_bytes` and change `parse` to accept `maxSamples` and return an error when the sample count exceeds the cap; cap discovery output by honoring `discovery.max_targets` while building the discovered target list. 
- Update docs and `config.example.yaml` to document the new safety limits and add unit tests covering oversized responses, oversized sample sets, discovery target caps, and validation failures.

### Testing

- Added unit tests: `TestScrape_MaxResponseBytesRejectsOversizedBody`, `TestScrape_MaxSamplesRejectsOversizedSampleSet`, `TestNodeDiscoverer_MaxTargetsCapsDiscovery`, and `TestValidateNodeMetricsRejectsBadLimits` which exercise the new limits. All new tests pass. 
- Ran the full test suite with `go test ./...` (includes `./internal/collector/nodemetrics`, `./internal/app`, `./internal/config`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20a98a91208324a16d1a14aa6a96c4)