### PR TITLE
fix(docs): redact live tailnet details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,9 @@ Match these locally before claiming work is done.
   validate record-type changes against real captures in `.capture/`.
 - **OTLP/HTTP endpoint path is used as-is:** the otlphttp exporter does NOT append `/v1/{metrics,logs}`
   — `internal/telemetry.otlpHTTPURL()` does. A bare gateway URL 404s silently without it.
-- **Real-tailnet verification:** the lab is `m7kni.io`; read-only OAuth + Grafana Cloud creds live in
-  gitignored `.secrets/creds.local.env` (`set -a; source .secrets/creds.local.env; set +a`), gcx
-  context `m7kni`. `gcx metrics|logs query` needs BOTH `--from` and `--to`. Only the lab may be
-  reconfigured — `auto_configure` must NEVER target a real/production tailnet.
+- **Live-tailnet verification:** keep lab-specific names, addresses, identifiers, credentials, and
+  observability captures out of tracked files. Store secrets and raw captures only in ignored local
+  paths. `gcx metrics|logs query` needs BOTH `--from` and `--to`; `auto_configure` must NEVER target a
+  real/production tailnet.
 - **Conventional Commits:** commit messages follow `type(scope): subject` (see `git log`); Renovate and
   release tooling assume it.

--- a/deploy/CLAUDE.md
+++ b/deploy/CLAUDE.md
@@ -7,7 +7,7 @@ consumed by operators or by the release pipelines.
 
 - `Dockerfile` — runtime image (built/smoke-tested in CI as `tailscale2otel:ci`).
   `Dockerfile.goreleaser` — the variant GoReleaser uses for the published multi-arch image.
-- `docker-compose.yaml` — local/single-host run (this is how it's deployed on `camden`).
+- `docker-compose.yaml` — local/single-host run (this is how it's deployed on `node-a`).
 - `helm/tailscale2otel/` — Helm chart (see below).
 - `grafana/*.json` — four importable Grafana 13 dashboards (fleet, network, audit-events,
   exporter-health). Datasource-agnostic via `${DS_PROM}`/`${DS_LOKI}` vars. See `grafana/README.md`.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -273,7 +273,7 @@ func postStream(t *testing.T, a *App, body string) int {
 // connection reported by BOTH the poll collector and the stream receiver is
 // counted ONCE. The flow dedup key is content-based (nodeId|start|end|proto|src|dst),
 // byte-identical across the two sources, so the shared set suppresses the second
-// copy. (Verified live against the m7kni lab on 2026-06-03: an identical flow
+// copy. (Verified live against the example-tailnet lab on 2026-06-03: an identical flow
 // replayed through the receiver did not double-count.)
 func TestPollStreamCrossDedup_FlowDeduplicates(t *testing.T) {
 	cfg := config.Default()
@@ -325,7 +325,7 @@ func TestPollStreamCrossDedup_FlowDeduplicates(t *testing.T) {
 // (time-free), so a change reported by BOTH paths is counted ONCE. This is a
 // best-effort FAILSAFE for the discouraged dual-ingestion config (source=both):
 // the supported setup is to pick ONE method per log type. (S4-9(2), verified live
-// against m7kni 2026-06-03; key change is the session-6 fix.)
+// against example-tailnet 2026-06-03; key change is the session-6 fix.)
 func TestPollStreamCrossDedup_AuditDeduplicates(t *testing.T) {
 	cfg := config.Default()
 	cfg.Tailscale.Tailnet = "example.com"

--- a/internal/audit/processor_test.go
+++ b/internal/audit/processor_test.go
@@ -183,25 +183,25 @@ func TestProcessAllEmitsPerEvent(t *testing.T) {
 // fail, and each variant must render to the expected attribute string.
 const polymorphicConfigBody = `{
   "version": "1.1",
-  "tailnetId": "m7kni.io",
+  "tailnetId": "example.com",
   "logs": [
     {
       "eventTime": "2026-06-02T19:00:05.558078907Z",
       "type": "CONFIG",
       "eventGroupID": "g-string",
       "origin": "NODE",
-      "actor": {"id":"u1","type":"USER","loginName":"rob@m7kni.io","displayName":"Rob"},
+      "actor": {"id":"u1","type":"USER","loginName":"alice@example.com","displayName":"Alice"},
       "target": {"id":"n1","name":"node.ts.net","type":"NODE","property":"MACHINE_NAME"},
       "action": "UPDATE",
       "old": "",
-      "new": "grafanacloud-1217581-tailscale-grafana-pdc-48"
+      "new": "service-node"
     },
     {
       "eventTime": "2026-06-02T19:00:05.558376389Z",
       "type": "CONFIG",
       "eventGroupID": "g-object",
       "origin": "ADMIN_CONSOLE",
-      "actor": {"id":"u1","type":"USER","loginName":"rob@m7kni.io","displayName":"Rob"},
+      "actor": {"id":"u1","type":"USER","loginName":"alice@example.com","displayName":"Alice"},
       "target": {"id":"n1","name":"node.ts.net","type":"NODE","property":"POSTURE"},
       "action": "UPDATE",
       "old": {"PostureDisabled":false},
@@ -212,7 +212,7 @@ const polymorphicConfigBody = `{
       "type": "CONFIG",
       "eventGroupID": "g-array",
       "origin": "NODE",
-      "actor": {"id":"u1","type":"USER","loginName":"rob@m7kni.io","displayName":"Rob"},
+      "actor": {"id":"u1","type":"USER","loginName":"alice@example.com","displayName":"Alice"},
       "target": {"id":"n1","name":"node.ts.net","type":"NODE","property":"ACL_TAGS"},
       "action": "UPDATE",
       "new": ["tag:grafana-pdc"]
@@ -222,7 +222,7 @@ const polymorphicConfigBody = `{
       "type": "CONFIG",
       "eventGroupID": "g-null",
       "origin": "NODE",
-      "actor": {"id":"u1","type":"USER","loginName":"rob@m7kni.io","displayName":"Rob"},
+      "actor": {"id":"u1","type":"USER","loginName":"alice@example.com","displayName":"Alice"},
       "target": {"id":"n1","name":"node.ts.net","type":"NODE"},
       "action": "CREATE",
       "old": null,
@@ -257,8 +257,8 @@ func TestProcessAllRendersPolymorphicOldNew(t *testing.T) {
 
 	// (a) JSON string new -> unquoted string; empty old absent.
 	str := byGroup["g-string"]
-	if got := str.Attrs["tailscale.audit.new"]; got != "grafanacloud-1217581-tailscale-grafana-pdc-48" {
-		t.Errorf("string new = %q, want unquoted grafanacloud-1217581-tailscale-grafana-pdc-48", got)
+	if got := str.Attrs["tailscale.audit.new"]; got != "service-node" {
+		t.Errorf("string new = %q, want unquoted service-node", got)
 	}
 	if _, ok := str.Attrs["tailscale.audit.old"]; ok {
 		t.Errorf("empty-string old should be absent, got %q", str.Attrs["tailscale.audit.old"])

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -8,7 +8,7 @@
 // # Envelope (PINNED by a live capture — S4-10)
 //
 // The exact wire format was captured from the real TailscaleLogStreamPublisher
-// against the m7kni lab (2026-06-03). Each POST body is one-or-more concatenated
+// against the example-tailnet lab (2026-06-03). Each POST body is one-or-more concatenated
 // Splunk-HEC objects with NO separators, each shaped:
 //
 //	{"time":<unixFloat>,"event":{<record>},"fields":{"recorded":<rfc3339>}}

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -148,14 +148,14 @@ const bareAuditRecord = `{"eventTime":"2026-06-02T12:00:30Z","type":"CONFIG","ev
 // TCP), srcNode/dstNodes node descriptors, and both virtualTraffic and
 // physicalTraffic arrays. The receiver must ignore the descriptive node fields
 // and route this to the flow processor on the strength of nodeId + traffic.
-const captureFlowRecord = `{"logged":"2026-06-02T19:00:01.346001489Z","nodeId":"nxrsyR7CNTRL","start":"2026-06-02T18:59:54.278418352Z","end":"2026-06-02T18:59:59.279306235Z","srcNode":{"nodeId":"nxrsyR7CNTRL","name":"camden.saga-turtle.ts.net","addresses":["100.91.77.97"],"tags":["tag:servers"]},"dstNodes":[{"nodeId":"nrx7wUpMaa11CNTRL","name":"mbp16.saga-turtle.ts.net","addresses":["100.88.109.22"],"os":"macOS","user":"rob@m7kni.io"}],"virtualTraffic":[{"proto":6,"src":"100.91.77.97:22","dst":"100.88.109.22:58544","txPkts":51,"txBytes":6420}],"physicalTraffic":[{"src":"100.88.109.22:0","dst":"10.0.0.183:57532","txPkts":53,"txBytes":8708,"rxPkts":53,"rxBytes":7004}]}`
+const captureFlowRecord = `{"logged":"2026-06-02T19:00:01.346001489Z","nodeId":"nFlowSrc1CNTRL","start":"2026-06-02T18:59:54.278418352Z","end":"2026-06-02T18:59:59.279306235Z","srcNode":{"nodeId":"nFlowSrc1CNTRL","name":"node-a.example.ts.net","addresses":["100.64.0.11"],"tags":["tag:servers"]},"dstNodes":[{"nodeId":"nFlowDst1CNTRL","name":"node-b.example.ts.net","addresses":["100.64.0.12"],"os":"macOS","user":"alice@example.com"}],"virtualTraffic":[{"proto":6,"src":"100.64.0.11:22","dst":"100.64.0.12:58544","txPkts":51,"txBytes":6420}],"physicalTraffic":[{"src":"100.64.0.12:0","dst":"10.0.0.183:57532","txPkts":53,"txBytes":8708,"rxPkts":53,"rxBytes":7004}]}`
 
 // captureAuditRecord mirrors the exact shape of a configuration-audit record
 // from a real capture (.capture/logging_config.json): an UPDATE whose "new" is
 // a JSON ARRAY ("new":["tag:grafana-pdc"]) and whose "old" is an empty STRING.
 // These polymorphic old/new values (string|object|array|null) must not derail
 // classification or decoding.
-const captureAuditRecord = `{"eventTime":"2026-06-02T19:00:05.558444283Z","type":"CONFIG","eventGroupID":"d3c5dde026b27ddd2e5601788dbecec6","origin":"NODE","actor":{"id":"uiffmH5CNTRL","type":"USER","loginName":"rob@m7kni.io","displayName":"Rob Knight"},"target":{"id":"n5FKuyvTaV11CNTRL","name":"grafanacloud-1217581-tailscale-grafana-pdc-48.saga-turtle.ts.net","type":"NODE","isEphemeral":true,"property":"ACL_TAGS"},"action":"UPDATE","old":"","new":["tag:grafana-pdc"]}`
+const captureAuditRecord = `{"eventTime":"2026-06-02T19:00:05.558444283Z","type":"CONFIG","eventGroupID":"egExample0000000000000000000000000001","origin":"NODE","actor":{"id":"uExample1CNTRL","type":"USER","loginName":"alice@example.com","displayName":"Alice Example"},"target":{"id":"nAuditTgt1CNTRL","name":"service-node.example.ts.net","type":"NODE","isEphemeral":true,"property":"ACL_TAGS"},"action":"UPDATE","old":"","new":["tag:grafana-pdc"]}`
 
 // assertFlowAndAuditOnce asserts that exactly one flow and one audit record
 // were processed and that no records were rejected.

--- a/internal/tsapi/devices_test.go
+++ b/internal/tsapi/devices_test.go
@@ -14,7 +14,7 @@ import (
 const devicesRichFixture = `{"devices":[
   {
     "id":"3690401478992208","nodeId":"nDdiWAbPpV11CNTRL","name":"laptop.example.ts.net",
-    "hostname":"laptop","os":"linux","user":"rob@example.com","clientVersion":"1.99.0",
+    "hostname":"laptop","os":"linux","user":"alice@example.com","clientVersion":"1.99.0",
     "addresses":["100.64.0.1","fd7a::1"],"tags":["tag:server","tag:prod"],
     "authorized":true,"isExternal":false,"updateAvailable":true,"keyExpiryDisabled":false,
     "connectedToControl":true,"blocksIncomingConnections":false,"sshEnabled":true,
@@ -24,7 +24,7 @@ const devicesRichFixture = `{"devices":[
     "clientConnectivity":{"latency":{"Frankfurt":{"preferred":true,"latencyMs":1.0156919999999998},"Amsterdam":{"latencyMs":8.675937999999999}}}
   },
   {
-    "id":"346670268899695","nodeId":"nt5gYXS1i311CNTRL","name":"alex.example.ts.net",
+    "id":"346670268899695","nodeId":"nExampleFlow11CNTRL","name":"alex.example.ts.net",
     "hostname":"alex","os":"macOS","user":"alex@example.com","clientVersion":"1.80.0",
     "addresses":["100.64.0.2"],
     "authorized":true,"isExternal":false,"updateAvailable":false,"keyExpiryDisabled":false,
@@ -72,7 +72,7 @@ func TestDevicesRich_DecodesRichFields(t *testing.T) {
 	if d0.ID != "3690401478992208" || d0.NodeID != "nDdiWAbPpV11CNTRL" {
 		t.Fatalf("ids = %q/%q", d0.ID, d0.NodeID)
 	}
-	if d0.Hostname != "laptop" || d0.OS != "linux" || d0.User != "rob@example.com" {
+	if d0.Hostname != "laptop" || d0.OS != "linux" || d0.User != "alice@example.com" {
 		t.Fatalf("basic = %+v", d0)
 	}
 	if d0.ClientVersion != "1.99.0" {


### PR DESCRIPTION
### Motivation
- The repo contained committed, live-tailnet operational and observability details (hostnames, node IDs, 100.x addresses, audit IDs, and owner context) which are sensitive reconnaissance data that must not be tracked in public documentation and tests.
- Preserve existing test coverage and record shapes while removing real-lab identifiers from tracked files and guidance.

### Description
- Replace live-tailnet guidance in documentation with a repository-safe reminder to keep lab-specific names, addresses, identifiers, credentials, and raw captures out of tracked files (changed `CLAUDE.md` and `deploy/CLAUDE.md`).
- Sanitize captured-stream comments and test fixtures to use example node IDs, hostnames, user addresses, and documentation-safe `100.64.0.0/10` IPs while keeping the original JSON shapes intact (changed `internal/stream/stream.go`, `internal/stream/stream_test.go`, `internal/audit/processor_test.go`, and `internal/tsapi/devices_test.go`).
- Redact live references in test comments (poll/stream dedup notes) and other prose to avoid exposing lab identifiers while preserving test intent and assertions (changed `internal/app/app_test.go`).

### Testing
- Ran `go test ./internal/stream ./internal/audit ./internal/tsapi ./internal/app -timeout=60s` and all targeted package tests passed.
- Ran `go test ./... -timeout=120s` and the full test suite passed with no failures.
- Ran a repository search (`rg`) for the known live identifiers and observed none remaining in tracked files after the sanitization step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20a98acb6083248c351e17f2429774)