### PR TITLE
Disable broad Renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "vulnerabilityAlerts": {
-    "automerge": true
+    "automerge": false
   },
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "lockFileMaintenance": {
     "enabled": true,
-    "automerge": true
+    "automerge": false
   },
   "automergeType": "pr",
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Never automerge release-please PRs - manual review required",
@@ -17,27 +17,27 @@
       "automerge": false
     },
     {
-      "description": "Automerge GitHub Actions",
+      "description": "Label GitHub Actions for manual review",
       "matchManagers": ["github-actions"],
       "labels": ["dep:gha"],
-      "automerge": true
+      "automerge": false
     },
     {
-      "description": "Automerge patch and minor updates for low risk",
+      "description": "Label patch and minor updates for manual review",
       "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
+      "automerge": false,
       "labels": ["dep:low-risk"]
     },
     {
-      "description": "Automerge pin updates",
+      "description": "Label pin updates for manual review",
       "matchUpdateTypes": ["pin"],
-      "automerge": true,
+      "automerge": false,
       "labels": ["dep:low-risk"]
     },
     {
-      "description": "Automerge digest updates (Docker, etc)",
+      "description": "Label digest updates (Docker, etc) for manual review",
       "matchUpdateTypes": ["digest"],
-      "automerge": true,
+      "automerge": false,
       "labels": ["dep:low-risk"]
     },
     {


### PR DESCRIPTION
### Motivation
- Close a supply-chain weakness introduced by broad Renovate automerge so dependency, action, and digest updates cannot be merged without human review.
- Prevent automatic merging of GitHub Actions updates which could modify workflows that run with elevated permissions.
- Keep existing grouping/labeling behavior so Renovate PRs are still surfaced for review instead of being silently merged.

### Description
- Set `vulnerabilityAlerts.automerge` to `false` to require review of alert-driven PRs.
- Set `lockFileMaintenance.automerge` to `false` and `platformAutomerge` to `false` to stop platform/lockfile automatic merges.
- Converted broad package rules for `github-actions`, `patch`/`minor`, `pin`, and `digest` updates to label-for-review rules by setting their `automerge` fields to `false` and updating descriptions to indicate manual review.
- Preserved existing specific rules that must remain unmerged (OpenTelemetry grouping and pre-1.0 Go modules) and kept `helpers:pinGitHubActionDigests` in `extends`.

### Testing
- Validated JSON syntax with `python -m json.tool renovate.json` which succeeded.
- Confirmed no remaining enabled automerge flags with `rg '"automerge"\s*:\s*true|"platformAutomerge"\s*:\s*true' renovate.json` which returned no matches.
- Ran `git diff --check` to ensure there are no whitespace/format issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20a8ad0f148324bf7b2fc2b43d1349)