### PR TITLE
fix(ci): pin sigstore/cosign-installer action to immutable commit

### DIFF
--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -106,9 +106,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # cosign for keyless chart signing. Pinned to a full v4 tag: cosign-installer
-      # publishes no moving `v4` tag, and installing cosign v3+ requires the v4 installer.
-      - uses: sigstore/cosign-installer@v4.1.2
+      # cosign for keyless chart signing. Pinned to the immutable commit for cosign-installer v4.1.2;
+      # installing cosign v3+ requires the v4 installer.
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
         with:
           cosign-release: 'v3.0.6'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # cosign (keyless image + checksum signing) and syft (SBOMs).
-      # Pinned to a full v4 tag: cosign-installer publishes no moving `v4` tag,
-      # and installing cosign v3+ (cosign-release below) REQUIRES the v4 installer.
-      - uses: sigstore/cosign-installer@v4.1.2
+      # Pinned to the immutable commit for cosign-installer v4.1.2;
+      # installing cosign v3+ (cosign-release below) REQUIRES the v4 installer.
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
         with:
           cosign-release: 'v3.0.6'
       - uses: anchore/sbom-action/download-syft@v0


### PR DESCRIPTION
### Motivation
- Close a supply-chain hardening gap by replacing the mutable `sigstore/cosign-installer@v4.1.2` tag with an immutable commit SHA so workflow code cannot be retargeted at runtime while running with privileged publishing permissions.
- Preserve the pinned cosign binary version via the existing `cosign-release: 'v3.0.6'` input so the tool version remains deterministic.

### Description
- Replace `sigstore/cosign-installer@v4.1.2` with the immutable commit `sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6` in `.github/workflows/main-publish.yml` for the chart signing step.
- Make the same replacement in `.github/workflows/release.yml` before the signing and GoReleaser steps.
- Leave the `cosign-release: 'v3.0.6'` input unchanged so the downloaded cosign binary version remains pinned.

### Testing
- Verified workflow files parse as YAML using `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: OK" }' .github/workflows/main-publish.yml .github/workflows/release.yml` and the check succeeded.
- Confirmed the action references were updated to a 40-character commit SHA with `rg -n "sigstore/cosign-installer@[0-9a-f]{40}|cosign-release" .github/workflows/main-publish.yml .github/workflows/release.yml` and the expected matches were found.
- Ran `git diff --check` to ensure no whitespace or diff-cleanliness issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a214b99df64832482cc0aebef96c84d)