### PR TITLE
fix: reserve node metrics identity label

### DIFF
--- a/internal/collector/nodemetrics/nodemetrics.go
+++ b/internal/collector/nodemetrics/nodemetrics.go
@@ -61,6 +61,12 @@ const (
 	// promotion, so per-node attribution survives.
 	attrInstance = "tailscale.node"
 
+	// attrInstancePromLabel is the Prometheus-normalized spelling of attrInstance.
+	// Scraped labels are untrusted and may legally include this key; carrying both
+	// keys would create a backend-dependent collision after OTLP->Prometheus
+	// normalization, so this raw scraped/passthrough key is reserved and stripped.
+	attrInstancePromLabel = "tailscale_node"
+
 	// metricDiscoverySuccess and metricDiscoveredTargets are the discovery-health
 	// gauges emitted every Collect when a Discoverer is configured.
 	metricDiscoverySuccess  = "tailscale2otel.nodemetrics.discovery.success"
@@ -707,13 +713,22 @@ func (c *Collector) emitDelta(s *sample, attrs telemetry.Attrs, e telemetry.Emit
 
 // mergeAttrs builds the per-sample attribute set: target passthrough labels
 // first, then parsed metric labels (which win on conflict), then the
-// tailscale.node identity label (which always wins). All values are strings.
+// tailscale.node identity label (which always wins). The Prometheus-normalized
+// identity spelling (tailscale_node) is reserved and stripped from scraped and
+// passthrough labels to prevent normalized-key collisions in OTLP backends. All
+// values are strings.
 func mergeAttrs(targetLabels, metricLabels map[string]string, instance string) telemetry.Attrs {
 	out := make(telemetry.Attrs, len(targetLabels)+len(metricLabels)+1)
 	for k, v := range targetLabels {
+		if k == attrInstancePromLabel {
+			continue
+		}
 		out[k] = v
 	}
 	for k, v := range metricLabels {
+		if k == attrInstancePromLabel {
+			continue
+		}
 		out[k] = v
 	}
 	out[attrInstance] = instance

--- a/internal/collector/nodemetrics/nodemetrics_test.go
+++ b/internal/collector/nodemetrics/nodemetrics_test.go
@@ -368,6 +368,40 @@ func TestLabelPassthrough(t *testing.T) {
 	}
 }
 
+func TestReservedPrometheusIdentityLabelIsStripped(t *testing.T) {
+	body := `# TYPE g gauge
+g{tailscale_node="spoofed",region="eu"} 1
+`
+	srv := serveText(&body)
+	defer srv.Close()
+
+	c := nodemetrics.New(nodemetrics.Options{
+		Targets: []nodemetrics.Target{{
+			URL:      srv.URL,
+			Instance: "node-a",
+			Labels:   map[string]string{"tailscale_node": "target-spoof", "role": "relay"},
+		}},
+	})
+	rec := telemetrytest.New()
+	if err := c.Collect(context.Background(), rec.Emitter()); err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	pts := rec.MetricPoints("g")
+	if len(pts) != 1 {
+		t.Fatalf("g points = %d, want 1; pts=%+v", len(pts), pts)
+	}
+	p := pts[0]
+	if p.Attrs["tailscale.node"] != "node-a" {
+		t.Fatalf("tailscale.node label = %q, want actual node identity", p.Attrs["tailscale.node"])
+	}
+	if _, ok := p.Attrs["tailscale_node"]; ok {
+		t.Fatalf("reserved normalized identity label present = %q, want stripped", p.Attrs["tailscale_node"])
+	}
+	if p.Attrs["region"] != "eu" || p.Attrs["role"] != "relay" {
+		t.Fatalf("non-reserved labels = %+v, want region and role preserved", p.Attrs)
+	}
+}
+
 func TestHealthUp_OnSuccess(t *testing.T) {
 	body := "# TYPE g gauge\ng 1\n"
 	srv := serveText(&body)


### PR DESCRIPTION
### Motivation
- Scraped Prometheus labels can use the normalized spelling `tailscale_node`, which collides with the OTEL attribute `tailscale.node` after backend normalization and allows a target to spoof or clobber node identity.
- The change prevents attacker-controlled scrape targets from creating backend-dependent label collisions that break node-level attribution and alerts.

### Description
- Add a reserved normalized identity constant `attrInstancePromLabel = "tailscale_node"` to document and treat the Prometheus spelling as untrusted. 
- Strip/skip the reserved `tailscale_node` key from both target passthrough labels and parsed metric labels in `mergeAttrs` before adding the trusted `tailscale.node` identity attribute. 
- Add `TestReservedPrometheusIdentityLabelIsStripped` to verify that a scraped `tailscale_node` label and a target passthrough `tailscale_node` are removed while preserving the real `tailscale.node` identity and other labels.

### Testing
- Ran `go test ./internal/collector/nodemetrics` and the package tests passed. 
- Ran `go test ./...` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21f37acc90832486fb0d382dde00ed)