### PR TITLE
ci: run API drift daily instead of weekly

### DIFF
--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -2,7 +2,7 @@ name: API drift
 
 on:
   schedule:
-    - cron: "17 6 * * 1" # Mondays 06:17 UTC
+    - cron: "17 6 * * *" # daily 06:17 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Bumps the `api-drift` schedule from weekly (Mondays) to daily, matching the new daily cadence in the meraki-dashboard-exporter drift lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)