### PR TITLE
ci(drift): support Claude Pro/Max OAuth token for enrichment

### DIFF
--- a/.github/actions/report-drift/action.yml
+++ b/.github/actions/report-drift/action.yml
@@ -17,7 +17,14 @@ inputs:
       Anthropic API key. Passed explicitly (not via job env) so lanes that execute
       UNTRUSTED upstream code (e.g. clientlib-main, which builds tailscale-client-go@main)
       can withhold it — the secret then never shares an environment with that code, and
-      Claude enrichment is skipped there. Empty ⇒ enrichment skipped.
+      Claude enrichment is skipped there. Empty ⇒ use the OAuth token, or skip if both empty.
+  claude-code-oauth-token:
+    required: false
+    default: ""
+    description: >
+      Claude Pro/Max OAuth token (generate locally with `claude setup-token`). Alternative
+      to anthropic-api-key — runs enrichment against a Claude subscription instead of
+      pay-per-use API credits. Same explicit-passing boundary; withhold on untrusted lanes.
 runs:
   using: composite
   steps:
@@ -25,19 +32,23 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        INPUTS_LANE_LABEL: ${{ inputs.lane-label }}
+        INPUTS_REPORT_PATH: ${{ inputs.report-path }}
+        INPUTS_TITLE: ${{ inputs.title }}
       run: |
         set -euo pipefail
-        existing=$(gh issue list --label "${{ inputs.lane-label }}" --state open --json number -q '.[0].number // empty')
+        existing=$(gh issue list --label "${INPUTS_LANE_LABEL}" --state open --json number -q '.[0].number // empty')
         if [ -n "$existing" ]; then
-          gh issue comment "$existing" --body-file "${{ inputs.report-path }}"
+          gh issue comment "$existing" --body-file "${INPUTS_REPORT_PATH}"
         else
-          gh issue create --label "${{ inputs.lane-label }}" --title "${{ inputs.title }}" --body-file "${{ inputs.report-path }}"
+          gh issue create --label "${INPUTS_LANE_LABEL}" --title "${INPUTS_TITLE}" --body-file "${INPUTS_REPORT_PATH}"
         fi
     - name: Claude enrichment
-      if: ${{ inputs.anthropic-api-key != '' }}
+      if: ${{ inputs.anthropic-api-key != '' || inputs.claude-code-oauth-token != '' }}
       uses: anthropics/claude-code-action@eee73e2ae5399c561de4ff038aa7b36a7aa991a7 # v1.0.143
       with:
         anthropic_api_key: ${{ inputs.anthropic-api-key }}
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
         prompt: |
           A scheduled CI lane detected Tailscale API drift.
 
@@ -54,4 +65,6 @@ runs:
              secrets, or files outside internal/tsapi and spec/tailscale-api.json.
     - name: Fail the run
       shell: bash
-      run: 'echo "Drift detected — see issue labelled ${{ inputs.lane-label }}" >&2; exit 1'
+      run: 'echo "Drift detected — see issue labelled ${INPUTS_LANE_LABEL}" >&2; exit 1'
+      env:
+        INPUTS_LANE_LABEL: ${{ inputs.lane-label }}

--- a/.github/actions/resolve-drift/action.yml
+++ b/.github/actions/resolve-drift/action.yml
@@ -16,11 +16,12 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        INPUTS_LANE_LABEL: ${{ inputs.lane-label }}
       run: |
         set -euo pipefail
         # Close ALL open issues with this label (normally 0 or 1) so a clean run never
         # leaves a stale tracking issue behind.
-        for n in $(gh issue list --label "${{ inputs.lane-label }}" --state open --json number -q '.[].number'); do
-          gh issue comment "$n" --body "Lane \`${{ inputs.lane-label }}\` is green again — closing automatically. See ${RUN_URL}."
+        for n in $(gh issue list --label "${INPUTS_LANE_LABEL}" --state open --json number -q '.[].number'); do
+          gh issue comment "$n" --body "Lane \`${INPUTS_LANE_LABEL}\` is green again — closing automatically. See ${RUN_URL}."
           gh issue close "$n" --reason completed
         done

--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -58,8 +58,11 @@ jobs:
           title: "Tailscale OpenAPI drift on consumed operations"
           report-path: /tmp/drift.md
           # Source is the Tailscale-published OpenAPI spec (data, not code execution);
-          # the key is introduced only here, on the post-classification report step.
+          # the credential is introduced only here, on the post-classification report step.
+          # Provide EITHER: ANTHROPIC_API_KEY (pay-per-use) or CLAUDE_CODE_OAUTH_TOKEN
+          # (Claude Pro/Max subscription, via `claude setup-token`).
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Resolve tracking issue on clean run
         if: steps.drift.outputs.code == '0'

--- a/.github/workflows/live-contract.yml
+++ b/.github/workflows/live-contract.yml
@@ -84,7 +84,9 @@ jobs:
           title: "Live Tailscale API contract failing"
           report-path: /tmp/live.md
           # This lane executes only our own code (read-only API calls), so enrichment is safe.
+          # Provide EITHER ANTHROPIC_API_KEY (pay-per-use) or CLAUDE_CODE_OAUTH_TOKEN (Max sub).
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Resolve tracking issue on clean run
         # Only when the contract actually ran and passed — never on the creds-absent self-skip


### PR DESCRIPTION
Brings the drift-enrichment auth in line with meraki-dashboard-exporter: the `report-drift` composite action now accepts `claude-code-oauth-token` (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`) alongside `anthropic-api-key`, and both the `api-drift` and `live-contract` lanes pass it. Enrichment fires if **either** credential is set, so drift fixes can be proposed against a Claude Pro/Max subscription instead of pay-per-use API credits. Same explicit-passing security boundary (credential only introduced at the post-classification report step; withheld on untrusted lanes).

Also bundles pre-existing local hardening of `report-drift`/`resolve-drift` that was in the working tree (input values moved to `env:` vars to avoid script injection in `run:` blocks).

**To activate:** add the repo secret `CLAUDE_CODE_OAUTH_TOKEN` (or keep using `ANTHROPIC_API_KEY` — both work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)