### PR TITLE
bump Go toolchain to 1.26.6 for root + tool modules to unblock Renovate CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rknightion/tailscale2otel/v4
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.5.0

--- a/tools/apidrift/go.mod
+++ b/tools/apidrift/go.mod
@@ -3,7 +3,7 @@
 // tailscale2otel consumes, reporting drift with severity-ranked exit codes.
 module github.com/rknightion/tailscale2otel/v4/tools/apidrift
 
-go 1.26.5
+go 1.26.6
 
 require github.com/rknightion/tailscale2otel/v4 v4.0.0
 

--- a/tools/configcheck/go.mod
+++ b/tools/configcheck/go.mod
@@ -4,7 +4,7 @@
 // that JSON Schema draft-07 cannot express.
 module github.com/rknightion/tailscale2otel/v4/tools/configcheck
 
-go 1.26.5
+go 1.26.6
 
 require github.com/rknightion/tailscale2otel/v4 v4.0.0
 

--- a/tools/metricscatalog/go.mod
+++ b/tools/metricscatalog/go.mod
@@ -4,7 +4,7 @@
 // keeping the docs derived from code rather than hand-maintained.
 module github.com/rknightion/tailscale2otel/v4/tools/metricscatalog
 
-go 1.26.5
+go 1.26.6
 
 require github.com/rknightion/tailscale2otel/v4 v4.0.0
 

--- a/tools/promqlcheck/go.mod
+++ b/tools/promqlcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/rknightion/tailscale2otel/v4/tools/promqlcheck
 
-go 1.26.5
+go 1.26.6
 
 require github.com/prometheus/prometheus v0.313.2
 


### PR DESCRIPTION
### Motivation

- Renovate PRs were blocked by CI failures originating from `govulncheck`/toolchain mismatches and recent standard-library security fixes addressed in Go 1.26.6, so the repository `go` directive needed to be advanced to match the fixed toolchain used in verification.

### Description

- Updated the `go` directive from `1.26.5` to `1.26.6` in the root `go.mod` and in `tools/apidrift/go.mod`, `tools/configcheck/go.mod`, `tools/metricscatalog/go.mod`, and `tools/promqlcheck/go.mod`.
- The change keeps the root module and all CI-only tool modules aligned on the same Go minor version so CI jobs (especially `govulncheck` and the module-verify matrix) can run cleanly.
- No other dependency versions were altered.

### Testing

- Ran `go build ./...`, `go vet ./...`, and `go test -race ./...` with success across the root module.
- Installed `govulncheck` pinned to the newer toolchain via `GOTOOLCHAIN=go1.26.6 go install golang.org/x/vuln/cmd/govulncheck@v1.3.0` and ran `govulncheck ./...` across the root and tool modules with no vulnerabilities reported.
- Built and ran per-module verification for the tools (`go build`, `go vet`, `go test -race`) and executed `go run -C tools/promqlcheck . -root "$PWD"`, all of which completed successfully.
- Noted a local warning: the locally installed `golangci-lint` binary was built with Go 1.24 and cannot load a module targeting Go 1.26.6, but the CI action runs the correct linter binary and is expected to pass there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a818c252038832b9b7e1054f85d0824)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go version to 1.26.6 across the main project and supporting tools.
  * Keeps development and build environments aligned with the latest supported Go patch release.
  * No user-facing functionality or public interfaces have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->